### PR TITLE
Prevent mailgun-es6 from crashing when incorrect API key is used

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,13 +177,18 @@ class MailGun {
         });
 
         res.on('end', function() {
-          //Everything should be an object coming from Mailgun
-          data = JSON.parse(data);
-          if (res.statusCode == 200) {
-            resolve(data);
-          } else {
-            reject(data);
-          }
+	  try {
+            //Everything should be an object coming from Mailgun
+            data = JSON.parse(data);
+
+            if (res.statusCode == 200) {
+              resolve(data);
+            } else {
+              reject(data);
+            }
+	  } catch (e) {
+	    reject(e);
+	  }
         });
       });
 


### PR DESCRIPTION
In the event that an incorrect API key is used, MailGun will send back the text `Forbidden` instead of a JSON object. This change will prevent `mailgun-es6` from crashing when that happens.
